### PR TITLE
Improve cell type handling for sqlite3 `read_record`

### DIFF
--- a/dissect/sql/sqlite3.py
+++ b/dissect/sql/sqlite3.py
@@ -590,7 +590,10 @@ def read_record(fh, encoding):
             if type_ % 2 == 0:
                 val = fh.read((type_ - 12) // 2)
             else:
-                val = fh.read((type_ - 13) // 2).decode(encoding)
+                try:
+                    val = fh.read((type_ - 13) // 2).decode(encoding)
+                except UnicodeDecodeError as e:
+                    val = e.object
 
         values.append(val)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import os
+from typing import BinaryIO
 
 import pytest
 
 
-def open_data(name):
+def open_data(name: str) -> BinaryIO:
     return open(os.path.join(os.path.dirname(__file__), name), "rb")
 
 
 @pytest.fixture
-def sqlite_db():
+def sqlite_db() -> BinaryIO:
     return open_data("data/test.sqlite")


### PR DESCRIPTION
This PR aims to improve the `read_record` function of `sqlite3`.

Some cell types cannot be decoded to a string. Currently the `read_record` implementation assumes all data input with `type_ % 2 != 0` can be decoded, which is not always true. This fix adds a `try`/`except` for such edge cases and returns the raw bytes.