### PR TITLE
Improve constraints parsing (2)

### DIFF
--- a/dissect/sql/utils.py
+++ b/dissect/sql/utils.py
@@ -91,7 +91,7 @@ def parse_table_columns_constraints(sql: str) -> tuple[str | None, list[str], li
         elif "PRIMARY KEY" in column_type_constraint.upper():
             primary_key = column_name
 
-        if column_name.upper().startswith(
+        if "(" in column_def and column_name.upper().startswith(
             (
                 "CONSTRAINT",
                 "UNIQUE",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from dissect.sql.utils import parse_table_columns_constraints
 
 testdata = [
-    (
+    pytest.param(
         "CREATE TABLE foo (column1, column2 INTEGER NOT NULL PRIMARY KEY)",
         (
             "column2",
@@ -15,8 +15,9 @@ testdata = [
             ],
             [],
         ),
+        id="create-table-simple",
     ),
-    (
+    pytest.param(
         "CREATE TABLE something (\n  column1 INTEGER NOT NULL,\n  column2 INTEGER NOT NULL,\n"
         "value,\n  PRIMARY KEY ( column1, column2)\n);",
         (
@@ -30,8 +31,9 @@ testdata = [
                 "PRIMARY KEY ( column1, column2)",
             ],
         ),
+        id="create-table-constraint-pk",
     ),
-    (
+    pytest.param(
         "GaRbAgE FoOoOoO ( \n\tcolumn1\n\tsome expression (with (nested (braces))), "
         "column2 (()), CONSTRAINT (with( some\n(braces\n)\n))\n)",
         (
@@ -44,8 +46,9 @@ testdata = [
                 "CONSTRAINT (with( some\n(braces\n)\n))",
             ],
         ),
+        id="create-table-nested-braces",
     ),
-    (
+    pytest.param(
         "CREATE TABLE bar (column1, column2 INTEGER NOT NULL, PRIMARY KEY ( column2 ))",
         (
             "column2",
@@ -57,8 +60,9 @@ testdata = [
                 "PRIMARY KEY ( column2 )",
             ],
         ),
+        id="create-table-empty-column-constraint-pk",
     ),
-    (
+    pytest.param(
         "CREATE TABLE bla (column1, column2 INTEGER NOT NULL, PRIMARY KEY ( column1, column2 ))",
         (
             None,
@@ -70,8 +74,9 @@ testdata = [
                 "PRIMARY KEY ( column1, column2 )",
             ],
         ),
+        id="create-table-empty-column-constraint-multiple-pk",
     ),
-    (
+    pytest.param(
         "CREATE TABLE bla (userId, test, UNIQUE(userId, test))",
         (
             None,
@@ -83,8 +88,9 @@ testdata = [
                 "UNIQUE(userId, test)",
             ],
         ),
+        id="create-table-unique-constraint",
     ),
-    (
+    pytest.param(
         "CREATE TABLE something (\n  column1, -- comment\n  column2\n)",
         (
             None,
@@ -94,8 +100,9 @@ testdata = [
             ],
             [],
         ),
+        id="create-table-newline-comments",
     ),
-    (
+    pytest.param(
         'CREATE TABLE foo (\n  "column-1",\n  "column--2", -- comment\n  "column-`-\'-3" -- comment, "column-\\"4"\n)',
         (
             None,
@@ -106,6 +113,47 @@ testdata = [
             ],
             [],
         ),
+        id="create-table-newline-comments-quotes-backticks",
+    ),
+    # Windows Index database
+    pytest.param(
+        "CREATE TABLE TableName (Id INTEGER PRIMARY KEY, UniqueKey TEXT NOT NULL UNIQUE, Name TEXT NOT NULL)",
+        (
+            "Id",
+            [
+                ("Id", "INTEGER PRIMARY KEY"),
+                ("UniqueKey", "TEXT NOT NULL UNIQUE"),  # <- this should not end up in the constraints list
+                ("Name", "TEXT NOT NULL"),
+            ],
+            [],
+        ),
+        id="create-table-unique-in-column-name",
+    ),
+    # Mozilla Firefox moz_places
+    pytest.param(
+        "CREATE TABLE moz_places (   id INTEGER PRIMARY KEY, url LONGVARCHAR, title LONGVARCHAR, rev_host LONGVARCHAR, visit_count INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0 NOT NULL, typed INTEGER DEFAULT 0 NOT NULL, frecency INTEGER DEFAULT -1 NOT NULL, last_visit_date INTEGER , guid TEXT, foreign_count INTEGER DEFAULT 0 NOT NULL, url_hash INTEGER DEFAULT 0 NOT NULL , description TEXT, preview_image_url TEXT, origin_id INTEGER REFERENCES moz_origins(id))",  # noqa: E501
+        (
+            "id",
+            [
+                ("id", "INTEGER PRIMARY KEY"),
+                ("url", "LONGVARCHAR"),
+                ("title", "LONGVARCHAR"),
+                ("rev_host", "LONGVARCHAR"),
+                ("visit_count", "INTEGER DEFAULT 0"),
+                ("hidden", "INTEGER DEFAULT 0 NOT NULL"),
+                ("typed", "INTEGER DEFAULT 0 NOT NULL"),
+                ("frecency", "INTEGER DEFAULT -1 NOT NULL"),
+                ("last_visit_date", "INTEGER"),
+                ("guid", "TEXT"),
+                ("foreign_count", "INTEGER DEFAULT 0 NOT NULL"),  # <- this should not end up in the constraints list
+                ("url_hash", "INTEGER DEFAULT 0 NOT NULL"),
+                ("description", "TEXT"),
+                ("preview_image_url", "TEXT"),
+                ("origin_id", "INTEGER REFERENCES moz_origins(id)"),
+            ],
+            [],
+        ),
+        id="create-table-firefox-foreign-in-column-name",
     ),
 ]
 


### PR DESCRIPTION
Fix for parsing Windows.db Search Index files (and other SQLite3 databases with column names starting with `constraint`, `unique`, `check`, `foreign` and `primary`) for PR https://github.com/fox-it/dissect.target/pull/1254.